### PR TITLE
addall, r6sコマンド追加．

### DIFF
--- a/grouping.rb
+++ b/grouping.rb
@@ -43,26 +43,50 @@ end
 #参加者追加コマンド
 bot.command :add do |event, *code|
     #引数無しならユーザ名
-    player_name = (code[0] ? code[0] : event.user.name)
-    if player_list.include?(player_name)
-        event.send_message("#{player_name} は既に参加済み。")
-    else
-        player_list.push(player_name)
-        event.send_message("#{player_name} を追加しました。")
+    player_names = (code[0] ? code : [event.user.name])
+    added_names = []
+    canceled_names = []
+    player_names.each do |n|
+        if player_list.include?(n)
+            canceled_names << n
+        else
+            player_list << n
+            added_names << n
+        end
     end
+    messages = []
+    if !added_names.empty?
+        messages << "`#{added_names.join("`, `")}`を追加しました。"
+    end
+    if !canceled_names.empty?
+        messages << "`#{canceled_names.join("`, `")}`は既に参加済み。"
+    end
+    event.send_message(messages.join("\n"))
     puts player_list
 end
 
 #参加者削除コマンド
 bot.command [:remove, :rm] do |event, *code|
     #引数無しならユーザ名
-    player_name = (code[0] ? code[0] : event.user.name)
-    if player_list.include?(player_name)
-        player_list.delete(player_name)
-        event.send_message("#{player_name} をリストから削除しました。")
-    else
-        event.send_message("#{player_name} はおらんで。")
+    player_names = (code[0] ? code : [event.user.name])
+    removeed_names = []
+    canceled_names = []
+    player_names.each do |n|
+        if player_list.include?(n)
+            player_list.delete(n)
+            removeed_names << n
+        else
+            canceled_names << n
+        end
     end
+    messages = []
+    if !removeed_names.empty?
+        messages << "`#{removeed_names.join("`, `")}`をリストから削除しました。"
+    end
+    if !canceled_names.empty?
+        messages << "`#{canceled_names.join("`, `")}`はおらんで。"
+    end
+    event.send_message(messages.join("\n"))
     puts player_list
 end
 
@@ -72,7 +96,7 @@ bot.command [:list, :ls] do |event, *code|
     if player_list.empty?
         event.send_message("誰もリストにはおらんよ")
     else
-        event.send_message("#{player_list.join("\n")}")
+        event.send_message("```\n#{player_list.join("\n")}\n```")
     end
     puts player_list
 end

--- a/grouping.rb
+++ b/grouping.rb
@@ -41,7 +41,7 @@ bot.command :food do |event|
 end
 
 #参加者追加コマンド
-bot.command :add do |event, *code|
+bot.command [:add, :addme] do |event, *code|
     #引数無しならユーザ名
     player_names = (code[0] ? code : [event.user.name])
     added_names = []
@@ -66,7 +66,7 @@ bot.command :add do |event, *code|
 end
 
 #参加者削除コマンド
-bot.command [:remove, :rm] do |event, *code|
+bot.command [:remove, :rm, :removeme, :rmme] do |event, *code|
     #引数無しならユーザ名
     player_names = (code[0] ? code : [event.user.name])
     removeed_names = []
@@ -102,7 +102,7 @@ bot.command [:list, :ls] do |event, *code|
 end
 
 #参加者リスト初期化
-bot.command [:clear, :removeall, :rmall] do |event|
+bot.command [:clear, :clr, :removeall, :rmall] do |event|
     player_list.clear
     event.send_message("初期化完了。")
 end

--- a/grouping.rb
+++ b/grouping.rb
@@ -40,43 +40,45 @@ bot.command :food do |event|
     delete = File.delete("pic.png")
 end
 
-#プレイヤー追加コマンド
+#参加者追加コマンド
 bot.command :add do |event, *code|
-    player_name = code[0]
+    #引数無しならユーザ名
+    player_name = (code[0] ? code[0] : event.user.name)
     if player_list.include?(player_name)
-      event.send_message("#{code[0]} は既に参加済み。")
+        event.send_message("#{player_name} は既に参加済み。")
     else
-      player_list.push(player_name)
-      event.send_message("#{code[0]} を追加しました。")
+        player_list.push(player_name)
+        event.send_message("#{player_name} を追加しました。")
     end
     puts player_list
 end
 
-#プレイヤー追加コマンド
-bot.command :remove do |event, *code|
-    player_name = code[0]
+#参加者削除コマンド
+bot.command [:remove, :rm] do |event, *code|
+    #引数無しならユーザ名
+    player_name = (code[0] ? code[0] : event.user.name)
     if player_list.include?(player_name)
-      player_list.delete(player_name)
-      event.send_message("#{code[0]} をリストから削除しました。")
+        player_list.delete(player_name)
+        event.send_message("#{player_name} をリストから削除しました。")
     else
-      event.send_message("#{code[0]} はおらんで。")
+        event.send_message("#{player_name} はおらんで。")
     end
     puts player_list
 end
 
-#プレイヤー追加コマンド
-bot.command :list do |event, *code|
+#参加者リスト表示コマンド
+bot.command [:list, :ls] do |event, *code|
     player_name = code[0]
     if player_list.empty?
-      event.send_message("誰もリストにはおらんよ")
+        event.send_message("誰もリストにはおらんよ")
     else
-      event.send_message("#{player_list.join("\n")}")
+        event.send_message("#{player_list.join("\n")}")
     end
     puts player_list
 end
 
-# 参加者リスト初期化
-bot.command :clear do |event|
+#参加者リスト初期化
+bot.command [:clear, :removeall, :rmall] do |event|
     player_list.clear
     event.send_message("初期化完了。")
 end

--- a/grouping.rb
+++ b/grouping.rb
@@ -66,7 +66,7 @@ bot.command [:add, :addme] do |event, *code|
 end
 
 #発言者の居るボイスチャンネルのメンバーを全員参加者リストに追加
-bot.command :addall do |event, *code|
+bot.command :addall do |event|
     if event.user.voice_channel.nil?
         event.send_message("発言者の居るボイスチャンネルのメンバーを追加するコマンドです。\nどこかのボイスチャンネルに入って使用してください。")
     else

--- a/grouping.rb
+++ b/grouping.rb
@@ -65,6 +65,39 @@ bot.command [:add, :addme] do |event, *code|
     puts player_list
 end
 
+#発言者の居るボイスチャンネルのメンバーを全員参加者リストに追加
+bot.command :addall do |event, *code|
+    if event.user.voice_channel.nil?
+        event.send_message("発言者の居るボイスチャンネルのメンバーを追加するコマンドです。\nどこかのボイスチャンネルに入って使用してください。")
+    else
+        player_names = []
+        event.user.voice_channel.users.each do |u|
+            player_names << u.name
+        end
+        #ここからほとんどaddコマンドコピペ（どうにかしたい）
+        added_names = []
+        canceled_names = []
+        player_names.each do |n|
+            if player_list.include?(n)
+                canceled_names << n
+            else
+                player_list << n
+                added_names << n
+            end
+        end
+        messages = []
+        if !added_names.empty?
+            messages << "`#{added_names.join("`, `")}`を追加しました。"
+        end
+        if !canceled_names.empty?
+            messages << "`#{canceled_names.join("`, `")}`は既に参加済み。"
+        end
+        event.send_message(messages.join("\n"))
+        puts player_list
+        #コピペここまで
+    end
+end
+
 #参加者削除コマンド
 bot.command [:remove, :rm, :removeme, :rmme] do |event, *code|
     #引数無しならユーザ名
@@ -126,6 +159,43 @@ Good Luck, Have Fun!
 EOS
         )
     end
+end
+
+#一発で発言者の居るボイスチャンネルメンバー全員のチーム分け
+bot.command [:r6s, :r6] do |event|
+    #参加者リストを保持
+    tmp = player_list
+    #専用リストを作る
+    player_list = []
+    if event.user.voice_channel.nil?
+        event.send_message("発言者の居るボイスチャンネルのメンバーを参照するコマンドです。\nどこかのボイスチャンネルに入って使用してください。")
+    else
+        event.user.voice_channel.users.each do |u|
+            player_list << u.name
+        end
+        #ここからgroupingコマンドコピペ（どうにかしたい）
+        if player_list.length < 2
+            event.send_message("二人以上の参加者が必要です...")
+        else
+            team_list = player_list.sort_by{rand}.each_slice((player_list.length + 1) / 2).sort_by{rand}
+            event.send_message(<<"EOS"
+__**【BlueTeam】**__
+```
+#{team_list[0].join("\n")}
+```
+__**【OrangeTeam】**__
+```
+#{team_list[1].join("\n")}
+```
+Good Luck, Have Fun!
+EOS
+            )
+        end
+    end
+    #groupingコマンドコピペここまで
+    #参加者リストを戻す
+    player_list = tmp
+    return
 end
 
 # 鬼ごっこ

--- a/grouping.rb
+++ b/grouping.rb
@@ -109,28 +109,18 @@ end
 
 #プレイヤーのチーム分け
 bot.command [:grouping, :group, :gp] do |event|
-    blueteam_list   = []
-    orangeteam_list = []
-    if player_list.empty?
-        event.send_message("参加者は...誰一人居ませんでした...")
+    if player_list.length < 2
+        event.send_message("二人以上の参加者が必要です...")
     else
-        choise_number_list = [*(0..(player_list.length - 1))].sort_by{rand}
-        choise_number_list.each_with_index do |x, i|
-            puts player_list[x]
-            if i.odd?
-                orangeteam_list.push(player_list[x])
-            else
-                blueteam_list.push(player_list[x])
-            end
-        end
+        team_list = player_list.sort_by{rand}.each_slice((player_list.length + 1) / 2).sort_by{rand}
         event.send_message(<<"EOS"
 __**【BlueTeam】**__
 ```
-#{blueteam_list.join("\n")}
+#{team_list[0].join("\n")}
 ```
 __**【OrangeTeam】**__
 ```
-#{orangeteam_list.join("\n")}
+#{team_list[1].join("\n")}
 ```
 Good Luck, Have Fun!
 EOS

--- a/grouping.rb
+++ b/grouping.rb
@@ -84,27 +84,33 @@ bot.command [:clear, :removeall, :rmall] do |event|
 end
 
 #プレイヤーのチーム分け
-bot.command :grouping do |event|
+bot.command [:grouping, :group, :gp] do |event|
     blueteam_list   = []
     orangeteam_list = []
     if player_list.empty?
-     event.send_message("参加者は...誰一人居ませんでした...")
+        event.send_message("参加者は...誰一人居ませんでした...")
     else
-      choise_number_list = [*(0..(player_list.length - 1))].sort_by{rand}
-      choise_number_list.each_with_index do |x, i|
-        puts player_list[x]
-        if i.odd?
-          orangeteam_list.push(player_list[x])
-        else
-          blueteam_list.push(player_list[x])
+        choise_number_list = [*(0..(player_list.length - 1))].sort_by{rand}
+        choise_number_list.each_with_index do |x, i|
+            puts player_list[x]
+            if i.odd?
+                orangeteam_list.push(player_list[x])
+            else
+                blueteam_list.push(player_list[x])
+            end
         end
-      end
-      event.send_message("チーム分け完了")
-      event.send_message("【OrangeTeam】")
-      event.send_message("#{orangeteam_list.join("\n")}")
-      event.send_message("【BlueTeam】")
-      event.send_message("#{blueteam_list.join("\n")}")
-      event.send_message("Good Luck, Have Fun!")
+        event.send_message(<<"EOS"
+__**【BlueTeam】**__
+```
+#{blueteam_list.join("\n")}
+```
+__**【OrangeTeam】**__
+```
+#{orangeteam_list.join("\n")}
+```
+Good Luck, Have Fun!
+EOS
+        )
     end
 end
 

--- a/grouping.rb
+++ b/grouping.rb
@@ -4,9 +4,10 @@ require 'mechanize'
 
 # 環境変数のLoad
 bot = Discordrb::Commands::CommandBot.new(
-  token: ENV["DISCORD_TOKEN"] ,
-  client_id: ENV["DISCORD_CLIENT_ID"],
-  prefix:'/'
+    token: ENV["DISCORD_TOKEN"] ,
+    client_id: ENV["DISCORD_CLIENT_ID"],
+    prefix: ['/', '\\'],
+    command_doesnt_exist_message: 'そんなコマンドはないよ'
 )
 
 bot.command :hello do |event|


### PR DESCRIPTION
・addall（発言者の居るボイスチャンネルのメンバーを全員参加者リストに追加する）コマンド追加
・r6s（一発で発言者の居るボイスチャンネルメンバー全員のチーム分けする）コマンド追加
・add, removeコマンドに引数無しで自身を追加する機能を追加．
・add, removeコマンドに複数引数に対応する機能を追加．
・奇数時のgroupingコマンドでどちらが多数派になるかをランダム化．
・コマンドのプレフィックスに「\」を追加
・コマンドに各種エイリアスを追加